### PR TITLE
refactor: migrate to json_serializable-based toJson and mixin toString

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
           sdk: ${{ matrix.sdk }}
       - run: dart pub get
       - run: dart run build_runner build --delete-conflicting-outputs
-      - run: 'if ! git diff --quiet --exit-code; then exit 1; fi'
+      - run: 'if ! git diff --quiet --exit-code; then echo "Generated files are out of sync. Run: dart run build_runner build --delete-conflicting-outputs" && exit 1; fi'
       - run: dart format --output=none --set-exit-if-changed .
       - run: dart analyze
       - run: dart test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
         with:
           sdk: ${{ matrix.sdk }}
       - run: dart pub get
+      - run: dart run build_runner build --delete-conflicting-outputs
+      - run: 'if ! git diff --quiet --exit-code; then exit 1; fi'
       - run: dart format --output=none --set-exit-if-changed .
       - run: dart analyze
       - run: dart test

--- a/example/json_serializable_example.dart
+++ b/example/json_serializable_example.dart
@@ -1,8 +1,141 @@
-import 'package:fido2/src/ctap2/entities/credential_entities.dart';
+import 'package:fido2/fido2.dart';
 
 void main() {
+  // Entities
   final rp = PublicKeyCredentialRpEntity(id: 'example.com');
-  final jsonMap = rp.toJson();
-  print('toJson map: $jsonMap');
-  print('toString: $rp');
+  final user = PublicKeyCredentialUserEntity(
+    id: [1, 2, 3, 4],
+    name: 'user@example.com',
+    displayName: 'User Example',
+  );
+  final descriptor = PublicKeyCredentialDescriptor(
+    type: 'public-key',
+    id: [4, 5, 6, 7],
+    transports: ['usb'],
+  );
+  print('PublicKeyCredentialRpEntity.toJson: ${rp.toJson()}');
+  print('PublicKeyCredentialUserEntity.toJson: ${user.toJson()}');
+  print('PublicKeyCredentialDescriptor.toJson: ${descriptor.toJson()}');
+
+  // AuthenticatorInfo (minimal)
+  final info = AuthenticatorInfo(
+    versions: ['FIDO_2_1'],
+    aaguid: List.filled(16, 0),
+  );
+  print('AuthenticatorInfo.toJson: ${info.toJson()}');
+
+  // Requests
+  final makeReq = MakeCredentialRequest(
+    clientDataHash: List.filled(32, 1),
+    rp: rp,
+    user: user,
+    pubKeyCredParams: [
+      {
+        'type': 'public-key',
+        'alg': ES256.algorithm,
+      }
+    ],
+    excludeList: [descriptor],
+  );
+  print('MakeCredentialRequest.toJson: ${makeReq.toJson()}');
+
+  final getReq = GetAssertionRequest(
+    rpId: 'example.com',
+    clientDataHash: List.filled(32, 2),
+    allowList: [descriptor],
+  );
+  print('GetAssertionRequest.toJson: ${getReq.toJson()}');
+
+  final credMgmtReq = CredentialManagementRequest(subCommand: 1);
+  print('CredentialManagementRequest.toJson: ${credMgmtReq.toJson()}');
+
+  final clientPinReq = ClientPinRequest(
+    subCommand: ClientPinSubCommand.getPinRetries.value,
+  );
+  print('ClientPinRequest.toJson: ${clientPinReq.toJson()}');
+
+  // Responses (constructed directly for demo)
+  final makeResp = MakeCredentialResponse(
+    fmt: 'packed',
+    authData: [0, 1, 2],
+    attStmt: {'alg': ES256.algorithm},
+  );
+  print('MakeCredentialResponse.toJson: ${makeResp.toJson()}');
+
+  final getResp = GetAssertionResponse(
+    credential: descriptor,
+    authData: [3, 4, 5],
+    signature: [6, 7, 8],
+    user: user,
+    numberOfCredentials: 1,
+    userSelected: true,
+  );
+  print('GetAssertionResponse.toJson: ${getResp.toJson()}');
+
+  final es256 = ES256.fromPublicKey(
+    List.filled(32, 9),
+    List.filled(32, 10),
+  );
+  final credMgmtResp = CredentialManagementResponse(
+    existingResidentCredentialsCount: 1,
+    maxPossibleRemainingResidentCredentialsCount: 10,
+    rp: rp,
+    rpIdHash: [11, 12, 13],
+    totalRPs: 1,
+    user: user,
+    credentialId: descriptor,
+    publicKey: es256,
+    totalCredentials: 1,
+    credProtect: 2,
+    largeBlobKey: [14, 15],
+  );
+  print('CredentialManagementResponse.toJson: ${credMgmtResp.toJson()}');
+
+  final clientPinResp = ClientPinResponse(
+    keyAgreement: es256,
+    pinUvAuthToken: [16, 17, 18],
+    pinRetries: 8,
+    powerCycleState: false,
+    uvRetries: 3,
+  );
+  print('ClientPinResponse.toJson: ${clientPinResp.toJson()}');
+
+  // CTAP wrappers
+  final ctapOk = CtapResponse<String>(0, 'ok');
+  print('CtapResponse<String>.toJson: ${ctapOk.toJson()}');
+  final ctapErr = CtapError(CtapStatusCode.ctap1ErrInvalidCommand);
+  print('CtapError.toJson: ${ctapErr.toJson()}');
+
+  // CoseKey toJson
+  final eddsa = EdDSA.fromPublicKey(List.filled(32, 1));
+  print('EdDSA.toJson: ${eddsa.toJson()}');
+  final es256Key = ES256.fromPublicKey(List.filled(32, 2), List.filled(32, 3));
+  print('ES256.toJson: ${es256Key.toJson()}');
+  final ecdh = EcdhEsHkdf256.fromPublicKey(
+    List.filled(32, 4),
+    List.filled(32, 5),
+  );
+  print('EcdhEsHkdf256.toJson: ${ecdh.toJson()}');
+
+  // Credential Management helper entities
+  final meta = CmMetadata(
+    existingResidentCredentialsCount: 2,
+    maxPossibleRemainingResidentCredentialsCount: 5,
+  );
+  print('CmMetadata.toJson: ${meta.toJson()}');
+  final cmRp = CmRp(rp: rp, rpIdHash: [21, 22], totalRPs: 3);
+  print('CmRp.toJson: ${cmRp.toJson()}');
+  final cmCred = CmCredential(
+    user: user,
+    credentialId: descriptor,
+    publicKey: es256,
+    totalCredentials: 2,
+    credProtect: 1,
+    largeBlobKey: [23, 24],
+  );
+  print('CmCredential.toJson: ${cmCred.toJson()}');
+
+  // EncapsulateResult toJson
+  final enc = EncapsulateResult(es256Key, List.filled(32, 6));
+  print('EncapsulateResult.toJson: ${enc.toJson()}');
 }

--- a/example/json_serializable_example.dart
+++ b/example/json_serializable_example.dart
@@ -1,4 +1,6 @@
 import 'package:fido2/fido2.dart';
+import 'dart:typed_data';
+import 'package:cbor/cbor.dart';
 
 void main() {
   // Entities
@@ -138,4 +140,41 @@ void main() {
   // EncapsulateResult toJson
   final enc = EncapsulateResult(es256Key, List.filled(32, 6));
   print('EncapsulateResult.toJson: ${enc.toJson()}');
+
+  // AttestedCredentialData toJson
+  final attested = AttestedCredentialData(
+    aaguid: Uint8List.fromList(List.filled(16, 0xAA)),
+    credentialId: Uint8List.fromList([1, 2, 3, 4]),
+    credentialPublicKey: CborMap({
+      CborInt(BigInt.from(1)): CborInt(BigInt.from(2)),
+    }),
+  );
+  print('AttestedCredentialData.toJson: ${attested.toJson()}');
+
+  // RegistrationResult toJson
+  final reg = RegistrationResult(
+    credentialId: Uint8List.fromList([9, 8, 7]),
+    credentialPublicKey: CborMap({
+      CborInt(BigInt.from(1)): CborInt(BigInt.from(7)),
+    }),
+  );
+  print('RegistrationResult.toJson: ${reg.toJson()}');
+
+  // AuthenticatorData toJson
+  final authData = AuthenticatorData(
+    rpIdHash: Uint8List.fromList(List.filled(32, 0x11)),
+    flags: 0x85,
+    signCount: 123,
+    attestedCredentialData: attested,
+  );
+  print('AuthenticatorData.toJson: ${authData.toJson()}');
+
+  // VerificationResult toJson
+  final ver = VerificationResult(
+    userPresent: true,
+    userVerified: true,
+    signCount: 42,
+    authenticatorData: Uint8List.fromList([1, 2, 3, 4]),
+  );
+  print('VerificationResult.toJson: ${ver.toJson()}');
 }

--- a/example/json_serializable_example.dart
+++ b/example/json_serializable_example.dart
@@ -1,0 +1,8 @@
+import 'package:fido2/src/ctap2/entities/credential_entities.dart';
+
+void main() {
+  final rp = PublicKeyCredentialRpEntity(id: 'example.com');
+  final jsonMap = rp.toJson();
+  print('toJson map: $jsonMap');
+  print('toString: $rp');
+}

--- a/lib/fido2_server.dart
+++ b/lib/fido2_server.dart
@@ -5,3 +5,4 @@ export 'src/server/base.dart';
 export 'src/server/config.dart';
 export 'src/server/entities/authenticator_data.dart';
 export 'src/server/entities/registration_data.dart';
+export 'src/server/entities/verification_data.dart';

--- a/lib/src/ctap.dart
+++ b/lib/src/ctap.dart
@@ -1,5 +1,10 @@
-/// Represents response from Client to Authenticator Protocol (CTAP) devices
-class CtapResponse<T> {
+import 'package:fido2/src/utils/serialization.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'ctap.g.dart';
+
+@JsonSerializable(createFactory: false, genericArgumentFactories: true)
+class CtapResponse<T> with JsonToStringMixin {
   /// status code, see [CtapStatusCode]
   final int status;
   final T data;
@@ -7,14 +12,8 @@ class CtapResponse<T> {
   CtapResponse(this.status, this.data);
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('CtapResponse(');
-    buffer.writeln('  status: $status,');
-    buffer.writeln('  data: $data');
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() =>
+      _$CtapResponseToJson(this, (t) => t as Object?);
 }
 
 abstract class CtapDevice {
@@ -142,7 +141,7 @@ enum CtapStatusCode implements Comparable<CtapStatusCode> {
 }
 
 /// Represents an error retuned by CTAP device
-class CtapError extends Error {
+class CtapError extends Error with JsonToStringMixin {
   final CtapStatusCode status;
 
   /// Create an error from [CtapStatusCode]
@@ -154,12 +153,8 @@ class CtapError extends Error {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('CtapError(');
-    buffer.writeln('  status: ${status.value},');
-    buffer.writeln('  name: ${status.name}');
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => {
+        'status': status.value,
+        'name': status.name,
+      };
 }

--- a/lib/src/ctap.g.dart
+++ b/lib/src/ctap.g.dart
@@ -1,0 +1,16 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'ctap.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$CtapResponseToJson<T>(
+  CtapResponse<T> instance,
+  Object? Function(T value) toJsonT,
+) =>
+    <String, dynamic>{
+      'status': instance.status,
+      'data': toJsonT(instance.data),
+    };

--- a/lib/src/ctap2/credmgmt.dart
+++ b/lib/src/ctap2/credmgmt.dart
@@ -1,5 +1,4 @@
 import 'package:cbor/cbor.dart';
-import 'package:convert/convert.dart';
 import 'package:fido2/src/cose.dart';
 import 'package:fido2/src/ctap.dart';
 import 'package:fido2/src/ctap2/base.dart';
@@ -7,6 +6,10 @@ import 'package:fido2/src/ctap2/pin.dart';
 import 'package:fido2/src/ctap2/entities/authenticator_info.dart';
 import 'package:fido2/src/ctap2/entities/credential_entities.dart';
 import 'package:fido2/src/ctap2/requests/credential_mgmt.dart';
+import 'package:fido2/src/utils/serialization.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'credmgmt.g.dart';
 
 enum CredentialManagementSubCommand {
   getCredsMetadata(0x01),
@@ -32,7 +35,8 @@ enum CredentialManagementSubCommandParams {
   final int value;
 }
 
-class CmMetadata {
+@JsonSerializable(createFactory: false)
+class CmMetadata with JsonToStringMixin {
   final int existingResidentCredentialsCount;
   final int maxPossibleRemainingResidentCredentialsCount;
 
@@ -42,19 +46,11 @@ class CmMetadata {
   });
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('CmMetadata(');
-    buffer.writeln(
-        '  existingResidentCredentialsCount: $existingResidentCredentialsCount,');
-    buffer.writeln(
-        '  maxPossibleRemainingResidentCredentialsCount: $maxPossibleRemainingResidentCredentialsCount');
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$CmMetadataToJson(this);
 }
 
-class CmRp {
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class CmRp with JsonToStringMixin {
   final PublicKeyCredentialRpEntity rp;
   final List<int> rpIdHash;
   final int? totalRPs;
@@ -66,18 +62,11 @@ class CmRp {
   });
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('CmRp(');
-    buffer.writeln('  rp: $rp,');
-    buffer.writeln('  rpIdHash: ${hex.encode(rpIdHash)},');
-    if (totalRPs != null) buffer.writeln('  totalRPs: $totalRPs,');
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$CmRpToJson(this);
 }
 
-class CmCredential {
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class CmCredential with JsonToStringMixin {
   final PublicKeyCredentialUserEntity user;
   final PublicKeyCredentialDescriptor credentialId;
   final CoseKey publicKey;
@@ -95,24 +84,7 @@ class CmCredential {
   });
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('CmCredential(');
-    buffer.writeln('  user: $user,');
-    buffer.writeln('  credentialId: $credentialId,');
-    buffer.writeln('  publicKey: $publicKey,');
-    buffer.writeln('  credProtect: $credProtect,');
-
-    if (totalCredentials != null) {
-      buffer.writeln('  totalCredentials: $totalCredentials,');
-    }
-    if (largeBlobKey != null) {
-      buffer.writeln('  largeBlobKey: ${hex.encode(largeBlobKey!)},');
-    }
-
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$CmCredentialToJson(this);
 }
 
 class CredentialManagement {

--- a/lib/src/ctap2/credmgmt.g.dart
+++ b/lib/src/ctap2/credmgmt.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'credmgmt.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$CmMetadataToJson(CmMetadata instance) =>
+    <String, dynamic>{
+      'existingResidentCredentialsCount':
+          instance.existingResidentCredentialsCount,
+      'maxPossibleRemainingResidentCredentialsCount':
+          instance.maxPossibleRemainingResidentCredentialsCount,
+    };
+
+Map<String, dynamic> _$CmRpToJson(CmRp instance) => <String, dynamic>{
+      'rp': instance.rp.toJson(),
+      'rpIdHash': instance.rpIdHash,
+      'totalRPs': instance.totalRPs,
+    };
+
+Map<String, dynamic> _$CmCredentialToJson(CmCredential instance) =>
+    <String, dynamic>{
+      'user': instance.user.toJson(),
+      'credentialId': instance.credentialId.toJson(),
+      'publicKey': instance.publicKey.toJson(),
+      'totalCredentials': instance.totalCredentials,
+      'credProtect': instance.credProtect,
+      'largeBlobKey': instance.largeBlobKey,
+    };

--- a/lib/src/ctap2/entities/authenticator_info.dart
+++ b/lib/src/ctap2/entities/authenticator_info.dart
@@ -1,7 +1,11 @@
 import 'package:cbor/cbor.dart';
-import 'package:convert/convert.dart';
+import 'package:fido2/src/utils/serialization.dart';
+import 'package:json_annotation/json_annotation.dart';
 
-class AuthenticatorInfo {
+part 'authenticator_info.g.dart';
+
+@JsonSerializable(createFactory: false)
+class AuthenticatorInfo with JsonToStringMixin {
   static const int versionsIdx = 1;
   static const int extensionsIdx = 2;
   static const int aaguidIdx = 3;
@@ -165,62 +169,5 @@ class AuthenticatorInfo {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('AuthenticatorInfo(');
-    buffer.writeln('  versions: $versions,');
-    buffer.writeln('  aaguid: ${hex.encode(aaguid)},');
-
-    if (extensions != null) buffer.writeln('  extensions: $extensions,');
-    if (options != null) buffer.writeln('  options: $options,');
-    if (maxMsgSize != null) buffer.writeln('  maxMsgSize: $maxMsgSize,');
-    if (pinUvAuthProtocols != null) {
-      buffer.writeln('  pinUvAuthProtocols: $pinUvAuthProtocols,');
-    }
-    if (maxCredentialCountInList != null) {
-      buffer.writeln('  maxCredentialCountInList: $maxCredentialCountInList,');
-    }
-    if (maxCredentialIdLength != null) {
-      buffer.writeln('  maxCredentialIdLength: $maxCredentialIdLength,');
-    }
-    if (transports != null) buffer.writeln('  transports: $transports,');
-    if (algorithms != null) buffer.writeln('  algorithms: $algorithms,');
-    if (maxSerializedLargeBlobArray != null) {
-      buffer.writeln(
-          '  maxSerializedLargeBlobArray: $maxSerializedLargeBlobArray,');
-    }
-    if (forcePinChange != null) {
-      buffer.writeln('  forcePinChange: $forcePinChange,');
-    }
-    if (minPinLength != null) buffer.writeln('  minPinLength: $minPinLength,');
-    if (firmwareVersion != null) {
-      buffer.writeln('  firmwareVersion: $firmwareVersion,');
-    }
-    if (maxCredBlobLength != null) {
-      buffer.writeln('  maxCredBlobLength: $maxCredBlobLength,');
-    }
-    if (maxRpIdsForSetMinPinLength != null) {
-      buffer.writeln(
-          '  maxRpIdsForSetMinPinLength: $maxRpIdsForSetMinPinLength,');
-    }
-    if (preferredPlatformUvAttempts != null) {
-      buffer.writeln(
-          '  preferredPlatformUvAttempts: $preferredPlatformUvAttempts,');
-    }
-    if (uvModality != null) buffer.writeln('  uvModality: $uvModality,');
-    if (certifications != null) {
-      buffer.writeln('  certifications: $certifications,');
-    }
-    if (remainingDiscoverableCredentials != null) {
-      buffer.writeln(
-          '  remainingDiscoverableCredentials: $remainingDiscoverableCredentials,');
-    }
-    if (vendorPrototypeConfigCommands != null) {
-      buffer.writeln(
-          '  vendorPrototypeConfigCommands: $vendorPrototypeConfigCommands,');
-    }
-
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$AuthenticatorInfoToJson(this);
 }

--- a/lib/src/ctap2/entities/authenticator_info.g.dart
+++ b/lib/src/ctap2/entities/authenticator_info.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'authenticator_info.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$AuthenticatorInfoToJson(AuthenticatorInfo instance) =>
+    <String, dynamic>{
+      'versions': instance.versions,
+      'extensions': instance.extensions,
+      'aaguid': instance.aaguid,
+      'options': instance.options,
+      'maxMsgSize': instance.maxMsgSize,
+      'pinUvAuthProtocols': instance.pinUvAuthProtocols,
+      'maxCredentialCountInList': instance.maxCredentialCountInList,
+      'maxCredentialIdLength': instance.maxCredentialIdLength,
+      'transports': instance.transports,
+      'algorithms': instance.algorithms,
+      'maxSerializedLargeBlobArray': instance.maxSerializedLargeBlobArray,
+      'forcePinChange': instance.forcePinChange,
+      'minPinLength': instance.minPinLength,
+      'firmwareVersion': instance.firmwareVersion,
+      'maxCredBlobLength': instance.maxCredBlobLength,
+      'maxRpIdsForSetMinPinLength': instance.maxRpIdsForSetMinPinLength,
+      'preferredPlatformUvAttempts': instance.preferredPlatformUvAttempts,
+      'uvModality': instance.uvModality,
+      'certifications': instance.certifications,
+      'remainingDiscoverableCredentials':
+          instance.remainingDiscoverableCredentials,
+      'vendorPrototypeConfigCommands': instance.vendorPrototypeConfigCommands,
+    };

--- a/lib/src/ctap2/entities/credential_entities.dart
+++ b/lib/src/ctap2/entities/credential_entities.dart
@@ -1,7 +1,11 @@
 import 'package:cbor/cbor.dart';
-import 'package:convert/convert.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:fido2/src/utils/serialization.dart';
 
-class PublicKeyCredentialRpEntity {
+part 'credential_entities.g.dart';
+
+@JsonSerializable(createFactory: false)
+class PublicKeyCredentialRpEntity with JsonToStringMixin {
   final String id;
 
   PublicKeyCredentialRpEntity({required this.id});
@@ -19,16 +23,11 @@ class PublicKeyCredentialRpEntity {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('PublicKeyCredentialRpEntity(');
-    buffer.writeln('  id: $id');
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$PublicKeyCredentialRpEntityToJson(this);
 }
 
-class PublicKeyCredentialUserEntity {
+@JsonSerializable(createFactory: false)
+class PublicKeyCredentialUserEntity with JsonToStringMixin {
   final List<int> id;
   final String name;
   final String displayName;
@@ -56,18 +55,11 @@ class PublicKeyCredentialUserEntity {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('PublicKeyCredentialUserEntity(');
-    buffer.writeln('  id: ${hex.encode(id)},');
-    buffer.writeln('  name: $name,');
-    buffer.writeln('  displayName: $displayName');
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$PublicKeyCredentialUserEntityToJson(this);
 }
 
-class PublicKeyCredentialDescriptor {
+@JsonSerializable(createFactory: false)
+class PublicKeyCredentialDescriptor with JsonToStringMixin {
   final String type;
   final List<int> id;
   final List<String>? transports;
@@ -95,13 +87,5 @@ class PublicKeyCredentialDescriptor {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('PublicKeyCredentialDescriptor(');
-    buffer.writeln('  type: $type,');
-    buffer.writeln('  id: ${hex.encode(id)},');
-    if (transports != null) buffer.writeln('  transports: $transports,');
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$PublicKeyCredentialDescriptorToJson(this);
 }

--- a/lib/src/ctap2/entities/credential_entities.g.dart
+++ b/lib/src/ctap2/entities/credential_entities.g.dart
@@ -1,0 +1,29 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'credential_entities.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$PublicKeyCredentialRpEntityToJson(
+        PublicKeyCredentialRpEntity instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+    };
+
+Map<String, dynamic> _$PublicKeyCredentialUserEntityToJson(
+        PublicKeyCredentialUserEntity instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'displayName': instance.displayName,
+    };
+
+Map<String, dynamic> _$PublicKeyCredentialDescriptorToJson(
+        PublicKeyCredentialDescriptor instance) =>
+    <String, dynamic>{
+      'type': instance.type,
+      'id': instance.id,
+      'transports': instance.transports,
+    };

--- a/lib/src/ctap2/pin.dart
+++ b/lib/src/ctap2/pin.dart
@@ -11,22 +11,20 @@ import 'package:fido2/src/ctap2/base.dart';
 import 'package:fido2/src/ctap2/entities/authenticator_info.dart';
 import 'package:fido2/src/ctap2/requests/client_pin.dart';
 import 'package:quiver/collection.dart';
+import 'package:fido2/src/utils/serialization.dart';
+import 'package:json_annotation/json_annotation.dart';
 
-class EncapsulateResult {
+part 'pin.g.dart';
+
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class EncapsulateResult with JsonToStringMixin {
   final CoseKey coseKey;
   final List<int> sharedSecret;
 
   EncapsulateResult(this.coseKey, this.sharedSecret);
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('EncapsulateResult(');
-    buffer.writeln('  coseKey: $coseKey,');
-    buffer.writeln('  sharedSecret: ${hex.encode(sharedSecret)}');
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$EncapsulateResultToJson(this);
 }
 
 sealed class PinProtocol {

--- a/lib/src/ctap2/pin.g.dart
+++ b/lib/src/ctap2/pin.g.dart
@@ -1,0 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pin.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$EncapsulateResultToJson(EncapsulateResult instance) =>
+    <String, dynamic>{
+      'coseKey': instance.coseKey.toJson(),
+      'sharedSecret': instance.sharedSecret,
+    };

--- a/lib/src/ctap2/requests/client_pin.dart
+++ b/lib/src/ctap2/requests/client_pin.dart
@@ -1,9 +1,13 @@
 import 'package:cbor/cbor.dart';
-import 'package:convert/convert.dart';
 import 'package:fido2/src/cose.dart';
 import '../constants.dart';
+import 'package:fido2/src/utils/serialization.dart';
+import 'package:json_annotation/json_annotation.dart';
 
-class ClientPinRequest {
+part 'client_pin.g.dart';
+
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class ClientPinRequest with JsonToStringMixin {
   static const int pinUvAuthProtocolIdx = 1;
   static const int subCommandIdx = 2;
   static const int keyAgreementIdx = 3;
@@ -61,39 +65,11 @@ class ClientPinRequest {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('ClientPinRequest(');
-    buffer.writeln('  subCommand: $subCommand,');
-
-    if (pinUvAuthProtocol != null) {
-      buffer.writeln('  pinUvAuthProtocol: $pinUvAuthProtocol,');
-    }
-    if (keyAgreement != null) {
-      buffer.writeln('  keyAgreement: $keyAgreement,');
-    }
-    if (pinUvAuthParam != null) {
-      buffer.writeln('  pinUvAuthParam: ${hex.encode(pinUvAuthParam!)},');
-    }
-    if (newPinEnc != null) {
-      buffer.writeln('  newPinEnc: ${hex.encode(newPinEnc!)},');
-    }
-    if (pinHashEnc != null) {
-      buffer.writeln('  pinHashEnc: ${hex.encode(pinHashEnc!)},');
-    }
-    if (permissions != null) {
-      buffer.writeln('  permissions: $permissions,');
-    }
-    if (rpId != null) {
-      buffer.writeln('  rpId: $rpId,');
-    }
-
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$ClientPinRequestToJson(this);
 }
 
-class ClientPinResponse {
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class ClientPinResponse with JsonToStringMixin {
   static const int keyAgreementIdx = 1;
   static const int pinUvAuthTokenIdx = 2;
   static const int pinRetriesIdx = 3;
@@ -129,21 +105,5 @@ class ClientPinResponse {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('ClientPinResponse(');
-
-    if (keyAgreement != null) buffer.writeln('  keyAgreement: $keyAgreement,');
-    if (pinUvAuthToken != null) {
-      buffer.writeln('  pinUvAuthToken: ${hex.encode(pinUvAuthToken!)},');
-    }
-    if (pinRetries != null) buffer.writeln('  pinRetries: $pinRetries,');
-    if (powerCycleState != null) {
-      buffer.writeln('  powerCycleState: $powerCycleState,');
-    }
-    if (uvRetries != null) buffer.writeln('  uvRetries: $uvRetries,');
-
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$ClientPinResponseToJson(this);
 }

--- a/lib/src/ctap2/requests/client_pin.g.dart
+++ b/lib/src/ctap2/requests/client_pin.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'client_pin.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$ClientPinRequestToJson(ClientPinRequest instance) =>
+    <String, dynamic>{
+      'pinUvAuthProtocol': instance.pinUvAuthProtocol,
+      'subCommand': instance.subCommand,
+      'keyAgreement': instance.keyAgreement?.toJson(),
+      'pinUvAuthParam': instance.pinUvAuthParam,
+      'newPinEnc': instance.newPinEnc,
+      'pinHashEnc': instance.pinHashEnc,
+      'permissions': instance.permissions,
+      'rpId': instance.rpId,
+    };
+
+Map<String, dynamic> _$ClientPinResponseToJson(ClientPinResponse instance) =>
+    <String, dynamic>{
+      'keyAgreement': instance.keyAgreement?.toJson(),
+      'pinUvAuthToken': instance.pinUvAuthToken,
+      'pinRetries': instance.pinRetries,
+      'powerCycleState': instance.powerCycleState,
+      'uvRetries': instance.uvRetries,
+    };

--- a/lib/src/ctap2/requests/credential_mgmt.dart
+++ b/lib/src/ctap2/requests/credential_mgmt.dart
@@ -1,10 +1,14 @@
 import 'package:cbor/cbor.dart';
-import 'package:convert/convert.dart';
 import 'package:fido2/src/cose.dart';
 import '../constants.dart';
 import '../entities/credential_entities.dart';
+import 'package:fido2/src/utils/serialization.dart';
+import 'package:json_annotation/json_annotation.dart';
 
-class CredentialManagementRequest {
+part 'credential_mgmt.g.dart';
+
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class CredentialManagementRequest with JsonToStringMixin {
   static const int subCmdIdx = 1;
   static const int paramsIdx = 2;
   static const int pinUvAuthProtocolIdx = 3;
@@ -39,27 +43,11 @@ class CredentialManagementRequest {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('CredentialManagementRequest(');
-    buffer.writeln('  subCommand: $subCommand,');
-
-    if (params != null) {
-      buffer.writeln('  params: $params,');
-    }
-    if (pinUvAuthProtocol != null) {
-      buffer.writeln('  pinUvAuthProtocol: $pinUvAuthProtocol,');
-    }
-    if (pinUvAuthParam != null) {
-      buffer.writeln('  pinUvAuthParam: ${hex.encode(pinUvAuthParam!)},');
-    }
-
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$CredentialManagementRequestToJson(this);
 }
 
-class CredentialManagementResponse {
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class CredentialManagementResponse with JsonToStringMixin {
   static const int existingResidentCredentialsCountIdx = 1;
   static const int maxPossibleRemainingResidentCredentialsCountIdx = 2;
   static const int rpIdx = 3;
@@ -127,47 +115,5 @@ class CredentialManagementResponse {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('CredentialManagementResponse(');
-
-    if (existingResidentCredentialsCount != null) {
-      buffer.writeln(
-          '  existingResidentCredentialsCount: $existingResidentCredentialsCount,');
-    }
-    if (maxPossibleRemainingResidentCredentialsCount != null) {
-      buffer.writeln(
-          '  maxPossibleRemainingResidentCredentialsCount: $maxPossibleRemainingResidentCredentialsCount,');
-    }
-    if (rp != null) {
-      buffer.writeln('  rp: $rp,');
-    }
-    if (rpIdHash != null) {
-      buffer.writeln('  rpIdHash: ${hex.encode(rpIdHash!)},');
-    }
-    if (totalRPs != null) {
-      buffer.writeln('  totalRPs: $totalRPs,');
-    }
-    if (user != null) {
-      buffer.writeln('  user: $user,');
-    }
-    if (credentialId != null) {
-      buffer.writeln('  credentialId: $credentialId,');
-    }
-    if (publicKey != null) {
-      buffer.writeln('  publicKey: $publicKey,');
-    }
-    if (totalCredentials != null) {
-      buffer.writeln('  totalCredentials: $totalCredentials,');
-    }
-    if (credProtect != null) {
-      buffer.writeln('  credProtect: $credProtect,');
-    }
-    if (largeBlobKey != null) {
-      buffer.writeln('  largeBlobKey: ${hex.encode(largeBlobKey!)},');
-    }
-
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$CredentialManagementResponseToJson(this);
 }

--- a/lib/src/ctap2/requests/credential_mgmt.g.dart
+++ b/lib/src/ctap2/requests/credential_mgmt.g.dart
@@ -1,0 +1,34 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'credential_mgmt.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$CredentialManagementRequestToJson(
+        CredentialManagementRequest instance) =>
+    <String, dynamic>{
+      'subCommand': instance.subCommand,
+      'params': instance.params?.toJson(),
+      'pinUvAuthProtocol': instance.pinUvAuthProtocol,
+      'pinUvAuthParam': instance.pinUvAuthParam,
+    };
+
+Map<String, dynamic> _$CredentialManagementResponseToJson(
+        CredentialManagementResponse instance) =>
+    <String, dynamic>{
+      'existingResidentCredentialsCount':
+          instance.existingResidentCredentialsCount,
+      'maxPossibleRemainingResidentCredentialsCount':
+          instance.maxPossibleRemainingResidentCredentialsCount,
+      'rp': instance.rp?.toJson(),
+      'rpIdHash': instance.rpIdHash,
+      'totalRPs': instance.totalRPs,
+      'user': instance.user?.toJson(),
+      'credentialId': instance.credentialId?.toJson(),
+      'publicKey': instance.publicKey?.toJson(),
+      'totalCredentials': instance.totalCredentials,
+      'credProtect': instance.credProtect,
+      'largeBlobKey': instance.largeBlobKey,
+    };

--- a/lib/src/ctap2/requests/get_assertion.dart
+++ b/lib/src/ctap2/requests/get_assertion.dart
@@ -1,9 +1,13 @@
 import 'package:cbor/cbor.dart';
-import 'package:convert/convert.dart';
 import '../constants.dart';
 import '../entities/credential_entities.dart';
+import 'package:fido2/src/utils/serialization.dart';
+import 'package:json_annotation/json_annotation.dart';
 
-class GetAssertionRequest {
+part 'get_assertion.g.dart';
+
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class GetAssertionRequest with JsonToStringMixin {
   static const int rpIdIdx = 1;
   static const int clientDataHashIdx = 2;
   static const int allowListIdx = 3;
@@ -55,34 +59,11 @@ class GetAssertionRequest {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('GetAssertionRequest(');
-    buffer.writeln('  rpId: $rpId,');
-    buffer.writeln('  clientDataHash: ${hex.encode(clientDataHash)},');
-
-    if (allowList != null) {
-      buffer.writeln('  allowList: $allowList,');
-    }
-    if (extensions != null) {
-      buffer.writeln('  extensions: $extensions,');
-    }
-    if (options != null) {
-      buffer.writeln('  options: $options,');
-    }
-    if (pinAuth != null) {
-      buffer.writeln('  pinAuth: ${hex.encode(pinAuth!)},');
-    }
-    if (pinProtocol != null) {
-      buffer.writeln('  pinProtocol: $pinProtocol,');
-    }
-
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$GetAssertionRequestToJson(this);
 }
 
-class GetAssertionResponse {
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class GetAssertionResponse with JsonToStringMixin {
   static const int credentialIdx = 1;
   static const int authDataIdx = 2;
   static const int signatureIdx = 3;
@@ -129,27 +110,5 @@ class GetAssertionResponse {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('GetAssertionResponse(');
-    buffer.writeln('  credential: $credential,');
-    buffer.writeln('  authData: ${hex.encode(authData)},');
-    buffer.writeln('  signature: ${hex.encode(signature)},');
-
-    if (user != null) {
-      buffer.writeln('  user: $user,');
-    }
-    if (numberOfCredentials != null) {
-      buffer.writeln('  numberOfCredentials: $numberOfCredentials,');
-    }
-    if (userSelected != null) {
-      buffer.writeln('  userSelected: $userSelected,');
-    }
-    if (largeBlobKey != null) {
-      buffer.writeln('  largeBlobKey: ${hex.encode(largeBlobKey!)},');
-    }
-
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$GetAssertionResponseToJson(this);
 }

--- a/lib/src/ctap2/requests/get_assertion.g.dart
+++ b/lib/src/ctap2/requests/get_assertion.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'get_assertion.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$GetAssertionRequestToJson(
+        GetAssertionRequest instance) =>
+    <String, dynamic>{
+      'rpId': instance.rpId,
+      'clientDataHash': instance.clientDataHash,
+      'allowList': instance.allowList?.map((e) => e.toJson()).toList(),
+      'extensions': instance.extensions,
+      'options': instance.options,
+      'pinAuth': instance.pinAuth,
+      'pinProtocol': instance.pinProtocol,
+    };
+
+Map<String, dynamic> _$GetAssertionResponseToJson(
+        GetAssertionResponse instance) =>
+    <String, dynamic>{
+      'credential': instance.credential.toJson(),
+      'authData': instance.authData,
+      'signature': instance.signature,
+      'user': instance.user?.toJson(),
+      'numberOfCredentials': instance.numberOfCredentials,
+      'userSelected': instance.userSelected,
+      'largeBlobKey': instance.largeBlobKey,
+    };

--- a/lib/src/ctap2/requests/make_credential.dart
+++ b/lib/src/ctap2/requests/make_credential.dart
@@ -1,9 +1,13 @@
 import 'package:cbor/cbor.dart';
-import 'package:convert/convert.dart';
+import 'package:fido2/src/utils/serialization.dart';
+import 'package:json_annotation/json_annotation.dart';
 import '../constants.dart';
 import '../entities/credential_entities.dart';
 
-class MakeCredentialRequest {
+part 'make_credential.g.dart';
+
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class MakeCredentialRequest with JsonToStringMixin {
   static const int clientDataHashIdx = 1;
   static const int rpIdx = 2;
   static const int userIdx = 3;
@@ -68,39 +72,11 @@ class MakeCredentialRequest {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('MakeCredentialRequest(');
-    buffer.writeln('  clientDataHash: ${hex.encode(clientDataHash)},');
-    buffer.writeln('  rp: $rp,');
-    buffer.writeln('  user: $user,');
-    buffer.writeln('  pubKeyCredParams: $pubKeyCredParams,');
-
-    if (excludeList != null) {
-      buffer.writeln('  excludeList: $excludeList,');
-    }
-    if (extensions != null) {
-      buffer.writeln('  extensions: $extensions,');
-    }
-    if (options != null) {
-      buffer.writeln('  options: $options,');
-    }
-    if (pinAuth != null) {
-      buffer.writeln('  pinAuth: ${hex.encode(pinAuth!)},');
-    }
-    if (pinProtocol != null) {
-      buffer.writeln('  pinProtocol: $pinProtocol,');
-    }
-    if (enterpriseAttestation != null) {
-      buffer.writeln('  enterpriseAttestation: $enterpriseAttestation,');
-    }
-
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$MakeCredentialRequestToJson(this);
 }
 
-class MakeCredentialResponse {
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class MakeCredentialResponse with JsonToStringMixin {
   static const int fmtIdx = 1;
   static const int authDataIdx = 2;
   static const int attStmtIdx = 3;
@@ -133,21 +109,5 @@ class MakeCredentialResponse {
   }
 
   @override
-  String toString() {
-    final buffer = StringBuffer();
-    buffer.writeln('MakeCredentialResponse(');
-    buffer.writeln('  fmt: $fmt,');
-    buffer.writeln('  authData: ${hex.encode(authData)},');
-    buffer.writeln('  attStmt: $attStmt,');
-
-    if (epAtt != null) {
-      buffer.writeln('  epAtt: $epAtt,');
-    }
-    if (largeBlobKey != null) {
-      buffer.writeln('  largeBlobKey: ${hex.encode(largeBlobKey!)},');
-    }
-
-    buffer.write(')');
-    return buffer.toString();
-  }
+  Map<String, dynamic> toJson() => _$MakeCredentialResponseToJson(this);
 }

--- a/lib/src/ctap2/requests/make_credential.g.dart
+++ b/lib/src/ctap2/requests/make_credential.g.dart
@@ -1,0 +1,32 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'make_credential.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$MakeCredentialRequestToJson(
+        MakeCredentialRequest instance) =>
+    <String, dynamic>{
+      'clientDataHash': instance.clientDataHash,
+      'rp': instance.rp.toJson(),
+      'user': instance.user.toJson(),
+      'pubKeyCredParams': instance.pubKeyCredParams,
+      'excludeList': instance.excludeList?.map((e) => e.toJson()).toList(),
+      'extensions': instance.extensions,
+      'options': instance.options,
+      'pinAuth': instance.pinAuth,
+      'pinProtocol': instance.pinProtocol,
+      'enterpriseAttestation': instance.enterpriseAttestation,
+    };
+
+Map<String, dynamic> _$MakeCredentialResponseToJson(
+        MakeCredentialResponse instance) =>
+    <String, dynamic>{
+      'fmt': instance.fmt,
+      'authData': instance.authData,
+      'attStmt': instance.attStmt,
+      'epAtt': instance.epAtt,
+      'largeBlobKey': instance.largeBlobKey,
+    };

--- a/lib/src/server/entities/authenticator_data.dart
+++ b/lib/src/server/entities/authenticator_data.dart
@@ -1,10 +1,16 @@
 import 'dart:typed_data';
 
 import 'package:cbor/cbor.dart';
+import 'package:fido2/src/utils/serialization.dart';
+
+import 'package:json_annotation/json_annotation.dart';
+
+part 'authenticator_data.g.dart';
 
 /// Data parsed from the `attestedCredentialData` block of an `authenticatorData`
 /// buffer. This contains the credential information.
-class AttestedCredentialData {
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class AttestedCredentialData with JsonToStringMixin {
   /// The AAGUID of the authenticator.
   final Uint8List aaguid;
 
@@ -19,6 +25,9 @@ class AttestedCredentialData {
     required this.credentialId,
     required this.credentialPublicKey,
   });
+
+  @override
+  Map<String, dynamic> toJson() => _$AttestedCredentialDataToJson(this);
 }
 
 /// A structured representation of the `authenticatorData` buffer returned
@@ -26,7 +35,8 @@ class AttestedCredentialData {
 ///
 /// It provides a safe way to parse and access the different fields of the
 /// authenticator data.
-class AuthenticatorData {
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class AuthenticatorData with JsonToStringMixin {
   /// The SHA-256 hash of the RP ID.
   final Uint8List rpIdHash;
 
@@ -156,4 +166,7 @@ class AuthenticatorData {
       extensions: extensions,
     );
   }
+
+  @override
+  Map<String, dynamic> toJson() => _$AuthenticatorDataToJson(this);
 }

--- a/lib/src/server/entities/authenticator_data.g.dart
+++ b/lib/src/server/entities/authenticator_data.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'authenticator_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$AttestedCredentialDataToJson(
+        AttestedCredentialData instance) =>
+    <String, dynamic>{
+      'aaguid': instance.aaguid,
+      'credentialId': instance.credentialId,
+      'credentialPublicKey': instance.credentialPublicKey.toJson(),
+    };
+
+Map<String, dynamic> _$AuthenticatorDataToJson(AuthenticatorData instance) =>
+    <String, dynamic>{
+      'rpIdHash': instance.rpIdHash,
+      'flags': instance.flags,
+      'signCount': instance.signCount,
+      'attestedCredentialData': instance.attestedCredentialData?.toJson(),
+      'extensions': instance.extensions?.toJson(),
+      'userPresent': instance.userPresent,
+      'userVerified': instance.userVerified,
+      'hasAttestedCredentialData': instance.hasAttestedCredentialData,
+      'hasExtensions': instance.hasExtensions,
+    };

--- a/lib/src/server/entities/registration_data.dart
+++ b/lib/src/server/entities/registration_data.dart
@@ -1,9 +1,15 @@
 import 'dart:typed_data';
 
 import 'package:cbor/cbor.dart';
+import 'package:fido2/src/utils/serialization.dart';
+
+import 'package:json_annotation/json_annotation.dart';
+
+part 'registration_data.g.dart';
 
 /// The result of a successful registration verification.
-class RegistrationResult {
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class RegistrationResult with JsonToStringMixin {
   /// A unique identifier for the new credential.
   final Uint8List credentialId;
 
@@ -14,4 +20,7 @@ class RegistrationResult {
     required this.credentialId,
     required this.credentialPublicKey,
   });
+
+  @override
+  Map<String, dynamic> toJson() => _$RegistrationResultToJson(this);
 }

--- a/lib/src/server/entities/registration_data.g.dart
+++ b/lib/src/server/entities/registration_data.g.dart
@@ -1,0 +1,13 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'registration_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$RegistrationResultToJson(RegistrationResult instance) =>
+    <String, dynamic>{
+      'credentialId': instance.credentialId,
+      'credentialPublicKey': instance.credentialPublicKey.toJson(),
+    };

--- a/lib/src/server/entities/verification_data.dart
+++ b/lib/src/server/entities/verification_data.dart
@@ -1,7 +1,13 @@
 import 'dart:typed_data';
+import 'package:fido2/src/utils/serialization.dart';
+
+import 'package:json_annotation/json_annotation.dart';
+
+part 'verification_data.g.dart';
 
 /// The result of a successful assertion (verification).
-class VerificationResult {
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class VerificationResult with JsonToStringMixin {
   /// Whether the authenticator reported the user was present (UP flag).
   final bool userPresent;
 
@@ -20,4 +26,7 @@ class VerificationResult {
     required this.signCount,
     required this.authenticatorData,
   });
+
+  @override
+  Map<String, dynamic> toJson() => _$VerificationResultToJson(this);
 }

--- a/lib/src/server/entities/verification_data.g.dart
+++ b/lib/src/server/entities/verification_data.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'verification_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+Map<String, dynamic> _$VerificationResultToJson(VerificationResult instance) =>
+    <String, dynamic>{
+      'userPresent': instance.userPresent,
+      'userVerified': instance.userVerified,
+      'signCount': instance.signCount,
+      'authenticatorData': instance.authenticatorData,
+    };

--- a/lib/src/utils/serialization.dart
+++ b/lib/src/utils/serialization.dart
@@ -1,0 +1,7 @@
+import 'dart:convert';
+
+mixin JsonToStringMixin {
+  Map<String, dynamic> toJson();
+  @override
+  String toString() => jsonEncode(toJson());
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   crypto: ^3.0.6
   cryptography: ^2.7.0
   elliptic: ^0.3.11
+  json_annotation: ^4.9.0
   pointycastle: ^4.0.0
   quiver: ^3.2.2
 
@@ -20,3 +21,5 @@ dev_dependencies:
   lints: ^4.0.0
   test: ^1.25.8
   dart_pcsc: ^2.0.2
+  build_runner: ^2.6.0
+  json_serializable: ^6.11.0


### PR DESCRIPTION
## Current Progress
Implementing json_serializable + JsonToStringMixin for core/ctap2 and src/server entities and requests:
- Replace handwritten toString with JsonToStringMixin
- Generate toJson via json_serializable (createFactory: false, no fromJson needed)
- No behavioral changes; purely for logging/serialization consistency
- Configure github workflow CI for `dart run build_runner build` check.

## Special Cases
Two classes remain with manual toJson implementation:
- `CoseKey`: extends MapView`<int, dynamic>`, json_serializable incompatible. Manual toJson handles numeric key conversion.
- `CtapError`: extends `Error`, inherited StackTrace causes generation issues. Simple manual toJson for status + name.