### PR TITLE
docs: add detailed documentation and update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.0.5
+
+- Implement FIDO2 makeCredential/getAssertion with unit tests.
+- Add stateless WebAuthn Fido2Server (registration/assertion flows, rpIdHash/flags/signCount checks, ES256/EdDSA verification).
+- Expand COSE (EC2/OKP constants, CBOR map encoding, ES256 and EdDSA verifiers with strict DER parsing and low-S normalization) and add algorithm registry.
+- Migrate to json_serializable `toJson` and `JsonToStringMixin` for entities/requests; add CI build check; no behavioral changes.
+- Update dependencies (asn1lib, crypto, pointycastle) and bump `cbor`.
+- Split public API into `fido2_client.dart` (CTAP client) and `fido2_server.dart` (server); adjust top-level exports.
+
 ## 0.0.4
 
 - Fix some CborType related errors by bumping `cbor` to `6.2.0`

--- a/lib/src/ctap2/entities/authenticator_info.dart
+++ b/lib/src/ctap2/entities/authenticator_info.dart
@@ -4,6 +4,11 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'authenticator_info.g.dart';
 
+/// CTAP2 authenticatorGetInfo response structure (spec §6.4).
+///
+/// Represents the authenticator's capabilities and preferences reported via
+/// the `getInfo` command. Platforms should use this to tailor subsequent
+/// requests. Field meanings follow the CTAP2 specification.
 @JsonSerializable(createFactory: false)
 class AuthenticatorInfo with JsonToStringMixin {
   static const int versionsIdx = 1;
@@ -28,26 +33,68 @@ class AuthenticatorInfo with JsonToStringMixin {
   static const int remainingDiscoverableCredentialsIdx = 20;
   static const int vendorPrototypeConfigCommandsIdx = 21;
 
+  /// List of supported versions (e.g. "FIDO_2_1", "FIDO_2_0", "U2F_V2").
   final List<String> versions;
+
+  /// List of supported extensions, if any.
   final List<String>? extensions;
+
+  /// The claimed AAGUID (16 bytes).
   final List<int> aaguid;
+
+  /// Map of supported options and their boolean values.
   final Map<String, bool>? options;
+
+  /// Maximum message size supported by the authenticator.
   final int? maxMsgSize;
+
+  /// Supported PIN/UV auth protocols in order of preference.
   final List<int>? pinUvAuthProtocols;
+
+  /// Maximum number of credentials accepted in a list.
   final int? maxCredentialCountInList;
+
+  /// Maximum credential ID length.
   final int? maxCredentialIdLength;
+
+  /// Supported transports (mirrors WebAuthn `AuthenticatorTransport`).
   final List<String>? transports;
+
+  /// Supported algorithms for credential generation (most- to least-preferred).
   final List<Map<String, int>>? algorithms;
+
+  /// Maximum size in bytes of serialized large-blob array, if supported.
   final int? maxSerializedLargeBlobArray;
+
+  /// Whether a PIN change is required before certain operations.
   final bool? forcePinChange;
+
+  /// Minimum PIN length (Unicode code points) for ClientPIN.
   final int? minPinLength;
+
+  /// Firmware version for the authenticator model.
   final int? firmwareVersion;
+
+  /// Maximum `credBlob` length in bytes, if extension supported.
   final int? maxCredBlobLength;
+
+  /// Maximum number of RP IDs accepted by setMinPINLength subcommand.
   final int? maxRpIdsForSetMinPinLength;
+
+  /// Preferred number of UV attempts before fallback to PIN.
   final int? preferredPlatformUvAttempts;
+
+  /// User verification modality bit flags per FIDO Registry.
   final int? uvModality;
+
+  /// Creates an [AuthenticatorInfo] with values reported by the authenticator.
+  /// Authenticator certifications.
   final Map<String, int>? certifications;
+
+  /// Estimated number of additional discoverable credentials that can be stored.
   final int? remainingDiscoverableCredentials;
+
+  /// List of supported vendor prototype config command IDs.
   final List<int>? vendorPrototypeConfigCommands;
 
   AuthenticatorInfo({
@@ -74,6 +121,7 @@ class AuthenticatorInfo with JsonToStringMixin {
     this.vendorPrototypeConfigCommands,
   });
 
+  /// Encodes this structure to a CBOR map as defined by CTAP2 getInfo.
   List<int> encode() {
     final map = <int, dynamic>{};
     map[versionsIdx] = versions;
@@ -139,6 +187,7 @@ class AuthenticatorInfo with JsonToStringMixin {
     return cbor.encode(CborValue(map));
   }
 
+  /// Decodes a CBOR-encoded authenticatorGetInfo response into [AuthenticatorInfo].
   static AuthenticatorInfo decode(List<int> data) {
     final map = cbor.decode(data).toObject() as Map;
     return AuthenticatorInfo(

--- a/lib/src/ctap2/entities/credential_entities.dart
+++ b/lib/src/ctap2/entities/credential_entities.dart
@@ -4,18 +4,23 @@ import 'package:fido2/src/utils/serialization.dart';
 
 part 'credential_entities.g.dart';
 
+/// WebAuthn Relying Party (RP) parameters used during credential creation
+/// (see spec §5.4.2). Contains the RP identifier.
 @JsonSerializable(createFactory: false)
 class PublicKeyCredentialRpEntity with JsonToStringMixin {
+  /// A unique identifier for the Relying Party entity; sets the RP ID.
   final String id;
 
   PublicKeyCredentialRpEntity({required this.id});
 
+  /// Parses from a CBOR map as used in CTAP requests.
   factory PublicKeyCredentialRpEntity.fromCbor(Map<dynamic, dynamic> cbor) {
     return PublicKeyCredentialRpEntity(
       id: cbor['id'] as String,
     );
   }
 
+  /// Serializes this RP entity to a CBOR map for CTAP.
   CborValue toCbor() {
     return CborValue({
       'id': id,
@@ -26,10 +31,17 @@ class PublicKeyCredentialRpEntity with JsonToStringMixin {
   Map<String, dynamic> toJson() => _$PublicKeyCredentialRpEntityToJson(this);
 }
 
+/// WebAuthn user account parameters for credential creation (spec §5.4.3).
+/// Includes an opaque user handle and human-readable names.
 @JsonSerializable(createFactory: false)
 class PublicKeyCredentialUserEntity with JsonToStringMixin {
+  /// Opaque user handle (max 64 bytes). Used for auth decisions.
   final List<int> id;
+
+  /// Machine-readable account name (not for auth decisions).
   final String name;
+
+  /// Human-palatable display name. May be empty.
   final String displayName;
 
   PublicKeyCredentialUserEntity({
@@ -38,6 +50,7 @@ class PublicKeyCredentialUserEntity with JsonToStringMixin {
     required this.displayName,
   });
 
+  /// Parses from a CBOR map as used in CTAP requests.
   factory PublicKeyCredentialUserEntity.fromCbor(Map<dynamic, dynamic> cbor) {
     return PublicKeyCredentialUserEntity(
       id: (cbor['id'] as List).cast<int>(),
@@ -46,6 +59,7 @@ class PublicKeyCredentialUserEntity with JsonToStringMixin {
     );
   }
 
+  /// Serializes this user entity to a CBOR map for CTAP.
   CborValue toCbor() {
     return CborValue({
       'id': CborBytes(id),
@@ -58,15 +72,24 @@ class PublicKeyCredentialUserEntity with JsonToStringMixin {
   Map<String, dynamic> toJson() => _$PublicKeyCredentialUserEntityToJson(this);
 }
 
+/// Identifies a specific credential (spec §5.8.3). Used to hint which
+/// credentials to create or allow during operations.
 @JsonSerializable(createFactory: false)
 class PublicKeyCredentialDescriptor with JsonToStringMixin {
+  /// Type of the public key credential (e.g. "public-key"). Unknown types
+  /// are ignored by platforms.
   final String type;
+
+  /// Credential ID of the public key credential being referenced.
   final List<int> id;
+
+  /// Optional hint of how to reach the authenticator (transports).
   final List<String>? transports;
 
   PublicKeyCredentialDescriptor(
       {required this.type, required this.id, this.transports});
 
+  /// Parses from a CBOR map representation.
   factory PublicKeyCredentialDescriptor.fromCbor(Map<dynamic, dynamic> cbor) {
     return PublicKeyCredentialDescriptor(
       type: cbor['type'] as String,
@@ -75,6 +98,7 @@ class PublicKeyCredentialDescriptor with JsonToStringMixin {
     );
   }
 
+  /// Serializes this descriptor to a CBOR map for CTAP.
   CborValue toCbor() {
     final map = <String, dynamic>{
       'type': type,

--- a/lib/src/ctap2/requests/client_pin.dart
+++ b/lib/src/ctap2/requests/client_pin.dart
@@ -6,6 +6,10 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'client_pin.g.dart';
 
+/// CTAP2 authenticatorClientPIN (0x06) request (spec §6.5.5).
+///
+/// Used by platforms to perform key agreement, set/change a PIN, and obtain a
+/// pinUvAuthToken using a selected PIN/UV protocol.
 @JsonSerializable(createFactory: false, explicitToJson: true)
 class ClientPinRequest with JsonToStringMixin {
   static const int pinUvAuthProtocolIdx = 1;
@@ -17,13 +21,28 @@ class ClientPinRequest with JsonToStringMixin {
   static const int permissionsIdx = 9;
   static const int rpIdIdx = 10;
 
+  /// PIN/UV protocol version selected by the platform.
   final int? pinUvAuthProtocol;
+
+  /// Specific subCommand to execute (e.g., getPINRetries, setPIN).
   final int subCommand;
+
+  /// Platform key-agreement public key (COSE_Key) when required by subCommand.
   final CoseKey? keyAgreement;
+
+  /// Authenticator input MAC parameter for subCommand contexts.
   final List<int>? pinUvAuthParam;
+
+  /// Encrypted new PIN value.
   final List<int>? newPinEnc;
+
+  /// Encrypted proof-of-knowledge of the PIN.
   final List<int>? pinHashEnc;
+
+  /// Bitfield of permissions for the requested token.
   final int? permissions;
+
+  /// RP ID to bind to the permissions, if any.
   final String? rpId;
 
   ClientPinRequest({
@@ -37,6 +56,7 @@ class ClientPinRequest with JsonToStringMixin {
     this.rpId,
   });
 
+  /// Encodes this request as a CBOR map and prefixes the command byte.
   List<int> encode() {
     final map = <int, dynamic>{};
     if (pinUvAuthProtocol != null) {
@@ -68,6 +88,10 @@ class ClientPinRequest with JsonToStringMixin {
   Map<String, dynamic> toJson() => _$ClientPinRequestToJson(this);
 }
 
+/// CTAP2 authenticatorClientPIN (0x06) response (spec §6.5.5).
+///
+/// Returns the authenticator's key agreement key, an encrypted pinUvAuthToken,
+/// and retry counters where applicable.
 @JsonSerializable(createFactory: false, explicitToJson: true)
 class ClientPinResponse with JsonToStringMixin {
   static const int keyAgreementIdx = 1;
@@ -76,10 +100,19 @@ class ClientPinResponse with JsonToStringMixin {
   static const int powerCycleStateIdx = 4;
   static const int uvRetriesIdx = 5;
 
+  /// Authenticator public key for key agreement (COSE_Key).
   final CoseKey? keyAgreement;
+
+  /// Encrypted pinUvAuthToken.
   final List<int>? pinUvAuthToken;
+
+  /// Remaining PIN retries before lockout.
   final int? pinRetries;
+
+  /// Whether a power cycle is required before future PIN operations.
   final bool? powerCycleState;
+
+  /// Remaining UV retries before lockout.
   final int? uvRetries;
 
   ClientPinResponse({
@@ -90,6 +123,7 @@ class ClientPinResponse with JsonToStringMixin {
     this.uvRetries,
   });
 
+  /// Decodes a CBOR-encoded response into [ClientPinResponse].
   static ClientPinResponse decode(List<int> data) {
     final map = cbor.decode(data).toObject() as Map;
     final keyAgreementMap =

--- a/lib/src/ctap2/requests/credential_mgmt.dart
+++ b/lib/src/ctap2/requests/credential_mgmt.dart
@@ -7,6 +7,10 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'credential_mgmt.g.dart';
 
+/// CTAP2 authenticatorCredentialManagement (0x0A) request (spec §6.8).
+///
+/// Manages discoverable credentials on the authenticator (enumerate, delete,
+/// update, etc.).
 @JsonSerializable(createFactory: false, explicitToJson: true)
 class CredentialManagementRequest with JsonToStringMixin {
   static const int subCmdIdx = 1;
@@ -14,9 +18,16 @@ class CredentialManagementRequest with JsonToStringMixin {
   static const int pinUvAuthProtocolIdx = 3;
   static const int pinUvAuthParamIdx = 4;
 
+  /// The credential management subCommand being requested.
   final int subCommand;
+
+  /// Parameters CBOR map for the subCommand.
   final CborMap? params;
+
+  /// PIN/UV protocol version chosen by the platform.
   final int? pinUvAuthProtocol;
+
+  /// HMAC-SHA-256 (first 16 bytes) over contents using pinUvAuthToken.
   final List<int>? pinUvAuthParam;
 
   CredentialManagementRequest({
@@ -26,6 +37,7 @@ class CredentialManagementRequest with JsonToStringMixin {
     this.pinUvAuthParam,
   });
 
+  /// Encodes this request as a CBOR map and prefixes the command byte.
   List<int> encode() {
     final map = <int, dynamic>{};
     map[subCmdIdx] = subCommand;
@@ -46,6 +58,10 @@ class CredentialManagementRequest with JsonToStringMixin {
   Map<String, dynamic> toJson() => _$CredentialManagementRequestToJson(this);
 }
 
+/// CTAP2 authenticatorCredentialManagement (0x0A) response (spec §6.8).
+///
+/// Returns RP/user/credential information, counts, and key material depending
+/// on the subCommand.
 @JsonSerializable(createFactory: false, explicitToJson: true)
 class CredentialManagementResponse with JsonToStringMixin {
   static const int existingResidentCredentialsCountIdx = 1;
@@ -60,16 +76,37 @@ class CredentialManagementResponse with JsonToStringMixin {
   static const int credProtectIdx = 10;
   static const int largeBlobKeyIdx = 11;
 
+  /// Number of existing discoverable credentials on the authenticator.
   final int? existingResidentCredentialsCount;
+
+  /// Maximum additional discoverable credentials possible.
   final int? maxPossibleRemainingResidentCredentialsCount;
+
+  /// Relying Party information.
   final PublicKeyCredentialRpEntity? rp;
+
+  /// SHA-256 hash of the RP ID.
   final List<int>? rpIdHash;
+
+  /// Total number of RPs present on the authenticator.
   final int? totalRPs;
+
+  /// User information.
   final PublicKeyCredentialUserEntity? user;
+
+  /// Credential identifier.
   final PublicKeyCredentialDescriptor? credentialId;
+
+  /// Credential public key (COSE_Key).
   final CoseKey? publicKey;
+
+  /// Total number of credentials for the RP.
   final int? totalCredentials;
+
+  /// Credential protection policy value.
   final int? credProtect;
+
+  /// Large blob encryption key.
   final List<int>? largeBlobKey;
 
   CredentialManagementResponse({
@@ -86,6 +123,7 @@ class CredentialManagementResponse with JsonToStringMixin {
     this.largeBlobKey,
   });
 
+  /// Decodes a CBOR-encoded response into [CredentialManagementResponse].
   static CredentialManagementResponse decode(List<int> data) {
     final map = cbor.decode(data).toObject() as Map;
     final rpMap = (map[rpIdx] as Map?)?.cast<String, dynamic>();

--- a/lib/src/ctap2/requests/get_assertion.dart
+++ b/lib/src/ctap2/requests/get_assertion.dart
@@ -6,6 +6,9 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'get_assertion.g.dart';
 
+/// CTAP2 authenticatorGetAssertion (0x02) request (spec §6.2).
+///
+/// Requests an assertion for a given RP using a previously created credential.
 @JsonSerializable(createFactory: false, explicitToJson: true)
 class GetAssertionRequest with JsonToStringMixin {
   static const int rpIdIdx = 1;
@@ -16,12 +19,25 @@ class GetAssertionRequest with JsonToStringMixin {
   static const int pinAuthIdx = 6;
   static const int pinProtocolIdx = 7;
 
+  /// Relying party identifier.
   final String rpId;
+
+  /// Hash of the serialized client data.
   final List<int> clientDataHash;
+
+  /// Optional allow-list of credentials to constrain selection.
   final List<PublicKeyCredentialDescriptor>? allowList;
+
+  /// Extension inputs to influence authenticator operation.
   final Map<String, dynamic>? extensions;
+
+  /// Options map, e.g., {"up": true, "uv": false}.
   final Map<String, bool>? options;
+
+  /// Result of authenticate(pinUvAuthToken, clientDataHash), if present.
   final List<int>? pinAuth;
+
+  /// PIN/UV protocol version selected by the platform.
   final int? pinProtocol;
 
   GetAssertionRequest({
@@ -34,6 +50,7 @@ class GetAssertionRequest with JsonToStringMixin {
     this.pinProtocol,
   });
 
+  /// Encodes this request as a CBOR map and prefixes the command byte.
   List<int> encode() {
     final map = <int, dynamic>{};
     map[rpIdIdx] = CborString(rpId);
@@ -62,6 +79,10 @@ class GetAssertionRequest with JsonToStringMixin {
   Map<String, dynamic> toJson() => _$GetAssertionRequestToJson(this);
 }
 
+/// CTAP2 authenticatorGetAssertion (0x02) response (spec §6.2).
+///
+/// Returns the selected credential descriptor, authenticator data, signature,
+/// and optional user information and counts.
 @JsonSerializable(createFactory: false, explicitToJson: true)
 class GetAssertionResponse with JsonToStringMixin {
   static const int credentialIdx = 1;
@@ -72,12 +93,25 @@ class GetAssertionResponse with JsonToStringMixin {
   static const int userSelectedIdx = 6;
   static const int largeBlobKeyIdx = 7;
 
+  /// Credential used for the assertion.
   final PublicKeyCredentialDescriptor credential;
+
+  /// Raw authenticator data buffer.
   final List<int> authData;
+
+  /// Assertion signature.
   final List<int> signature;
+
+  /// Optional user entity information.
   final PublicKeyCredentialUserEntity? user;
+
+  /// Number of available credentials for subsequent getNextAssertion.
   final int? numberOfCredentials;
+
+  /// Whether the user actively selected a credential.
   final bool? userSelected;
+
+  /// Large-blob encryption key, if provided.
   final List<int>? largeBlobKey;
 
   GetAssertionResponse({
@@ -90,6 +124,7 @@ class GetAssertionResponse with JsonToStringMixin {
     this.largeBlobKey,
   });
 
+  /// Decodes a CBOR-encoded response into [GetAssertionResponse].
   static GetAssertionResponse decode(List<int> data) {
     final map = cbor.decode(data).toObject() as Map;
     final credentialMap = map[credentialIdx] as Map?;

--- a/lib/src/ctap2/requests/get_info.dart
+++ b/lib/src/ctap2/requests/get_info.dart
@@ -1,6 +1,10 @@
 import '../constants.dart';
 
+/// CTAP2 authenticatorGetInfo (0x04) request.
+///
+/// Requests the authenticator's capabilities and preferences. Takes no inputs.
 class GetInfoRequest {
+  /// Encodes this request by returning the single command byte.
   List<int> encode() {
     return [Ctap2Commands.getInfo.value];
   }

--- a/lib/src/ctap2/requests/make_credential.dart
+++ b/lib/src/ctap2/requests/make_credential.dart
@@ -6,6 +6,10 @@ import '../entities/credential_entities.dart';
 
 part 'make_credential.g.dart';
 
+/// CTAP2 authenticatorMakeCredential (0x01) request (spec §6.1).
+///
+/// Requests generation of a new credential bound to an RP and user. Several
+/// fields mirror WebAuthn makeCredential parameters.
 @JsonSerializable(createFactory: false, explicitToJson: true)
 class MakeCredentialRequest with JsonToStringMixin {
   static const int clientDataHashIdx = 1;
@@ -19,15 +23,34 @@ class MakeCredentialRequest with JsonToStringMixin {
   static const int pinProtocolIdx = 9;
   static const int enterpriseAttestationIdx = 10;
 
+  /// Hash of serialized client data per WebAuthn.
   final List<int> clientDataHash;
+
+  /// Relying Party entity to associate with the credential.
   final PublicKeyCredentialRpEntity rp;
+
+  /// User entity to associate with the credential.
   final PublicKeyCredentialUserEntity user;
+
+  /// Preferred algorithms for credential generation (ordered, no duplicates).
   final List<Map<String, dynamic>> pubKeyCredParams;
+
+  /// Prevent duplicates by listing existing credentials for the account.
   final List<PublicKeyCredentialDescriptor>? excludeList;
+
+  /// Extension inputs to influence authenticator operation.
   final Map<String, dynamic>? extensions;
+
+  /// Additional boolean options (rk/up/uv) for operation.
   final Map<String, bool>? options;
+
+  /// Result of authenticate(pinUvAuthToken, clientDataHash), if present.
   final List<int>? pinAuth;
+
+  /// PIN/UV protocol version selected by the platform.
   final int? pinProtocol;
+
+  /// Request enterprise attestation behavior if supported.
   final bool? enterpriseAttestation;
 
   MakeCredentialRequest({
@@ -43,6 +66,7 @@ class MakeCredentialRequest with JsonToStringMixin {
     this.enterpriseAttestation,
   });
 
+  /// Encodes this request as a CBOR map and prefixes the command byte.
   List<int> encode() {
     final map = <int, dynamic>{};
     map[clientDataHashIdx] = CborBytes(clientDataHash);
@@ -75,6 +99,10 @@ class MakeCredentialRequest with JsonToStringMixin {
   Map<String, dynamic> toJson() => _$MakeCredentialRequestToJson(this);
 }
 
+/// CTAP2 authenticatorMakeCredential (0x01) response (spec §6.1).
+///
+/// Returns attestation format, authenticator data, attestation statement and
+/// optional enterprise attestation and large-blob key.
 @JsonSerializable(createFactory: false, explicitToJson: true)
 class MakeCredentialResponse with JsonToStringMixin {
   static const int fmtIdx = 1;
@@ -83,10 +111,19 @@ class MakeCredentialResponse with JsonToStringMixin {
   static const int epAttIdx = 4;
   static const int largeBlobKeyIdx = 5;
 
+  /// Attestation statement format identifier.
   final String fmt;
+
+  /// Raw authenticator data buffer.
   final List<int> authData;
+
+  /// Attestation statement object.
   final Map<String, dynamic> attStmt;
+
+  /// Whether enterprise attestation was performed.
   final bool? epAtt;
+
+  /// Large-blob encryption key, if provided.
   final List<int>? largeBlobKey;
 
   MakeCredentialResponse({
@@ -97,6 +134,7 @@ class MakeCredentialResponse with JsonToStringMixin {
     this.largeBlobKey,
   });
 
+  /// Decodes a CBOR-encoded response into [MakeCredentialResponse].
   static MakeCredentialResponse decode(List<int> data) {
     final map = cbor.decode(data).toObject() as Map;
     return MakeCredentialResponse(


### PR DESCRIPTION
- add detailed documentation for `AuthenticatorInfo`, credential entities and CTAP2 requests and responses;
- update CHANGELOG for version 0.0.5.