### PR TITLE
fix: make name and displayName optional in PublicKeyCredentialUserEntity

### DIFF
--- a/lib/src/ctap2/entities/credential_entities.dart
+++ b/lib/src/ctap2/entities/credential_entities.dart
@@ -39,33 +39,38 @@ class PublicKeyCredentialUserEntity with JsonToStringMixin {
   final List<int> id;
 
   /// Machine-readable account name (not for auth decisions).
-  final String name;
+  final String? name;
 
   /// Human-palatable display name. May be empty.
-  final String displayName;
+  final String? displayName;
 
   PublicKeyCredentialUserEntity({
     required this.id,
-    required this.name,
-    required this.displayName,
+    this.name,
+    this.displayName,
   });
 
   /// Parses from a CBOR map as used in CTAP requests.
   factory PublicKeyCredentialUserEntity.fromCbor(Map<dynamic, dynamic> cbor) {
     return PublicKeyCredentialUserEntity(
       id: (cbor['id'] as List).cast<int>(),
-      name: cbor['name'] as String,
-      displayName: cbor['displayName'] as String,
+      name: cbor['name'] as String?,
+      displayName: cbor['displayName'] as String?,
     );
   }
 
   /// Serializes this user entity to a CBOR map for CTAP.
   CborValue toCbor() {
-    return CborValue({
+    final map = <String, dynamic>{
       'id': CborBytes(id),
-      'name': name,
-      'displayName': displayName,
-    });
+    };
+    if (name != null) {
+      map['name'] = name;
+    }
+    if (displayName != null) {
+      map['displayName'] = displayName;
+    }
+    return CborValue(map);
   }
 
   @override


### PR DESCRIPTION
Client to Authenticator Protocol (CTAP) [spec 6.2](https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#sctn-getAssert-authnr-alg):

> FIDO Devices - [discoverable](https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#discoverable) credentials: For discoverable credentials on FIDO devices, at least [user](https://w3c.github.io/webauthn/#dictdef-publickeycredentialuserentity) "[id](https://w3c.github.io/webauthn/#dom-publickeycredentialuserentity-id)" is mandatory.
>
> For single account per RP case, authenticator returns "[id](https://w3c.github.io/webauthn/#dom-publickeycredentialuserentity-id)" field to the platform which will be returned to the [[WebAuthn]](https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#biblio-webauthn) layer.
>
> For multiple accounts per RP case, where the authenticator does not have a display, authenticator returns "id" as well as other fields to the platform. Platform will use this information to show the account selection UX to the user and for the user selected account, it will ONLY return "id" back to the [[WebAuthn]](https://fidoalliance.org/specs/fido-v2.2-rd-20230321/fido-client-to-authenticator-protocol-v2.2-rd-20230321.html#biblio-webauthn) layer and discard other user details.