### PR TITLE
feat: add metadata-only extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+- Add the metadata-only extension for credential enumeration, including
+  standard-response fallback.
+
 ## 1.1.0
 
 - Make `name` and `displayName` optional in `PublicKeyCredentialUserEntity`

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Future<void> demo(CtapDevice device) async {
 
 More end-to-end CTAP examples are in [`example/pcsc_example.dart`](example/pcsc_example.dart).
 
+Credential management also supports the
+[metadata-only extension](docs/metadata-only-extension.md) for efficiently
+listing credentials without transferring complete public keys.
+
 ## Usage — WebAuthn server
 
 The server is stateless; you persist challenges, public keys, and counters.

--- a/docs/metadata-only-extension.md
+++ b/docs/metadata-only-extension.md
@@ -1,0 +1,136 @@
+# Credential Management Metadata-Only Extension
+
+The metadata-only extension reduces the amount of data transferred while
+enumerating discoverable credentials. It is intended for management clients
+that need to list credentials but do not need each credential's complete
+public key.
+
+## Motivation
+
+The standard `enumerateCredentialsBegin` and
+`enumerateCredentialsGetNextCredential` responses include a COSE public key.
+That key is unnecessary for common management operations such as displaying a
+credential, selecting one for deletion, or updating its user information.
+
+Transferring every public key makes enumeration slower on constrained
+transports. The cost becomes more significant for algorithms whose public keys
+are substantially larger than traditional elliptic-curve keys. Omitting the
+key improves enumeration latency without removing any metadata needed by these
+management workflows.
+
+The extension reuses the standard credential management command and
+subcommands instead of defining a parallel enumeration protocol. This keeps
+the standard response fields, pagination behavior, authorization model, and
+error handling unchanged.
+
+## Begin Request
+
+The request uses `authenticatorCredentialManagement` (`0x0A`) with
+`enumerateCredentialsBegin` (`0x04`). The `subCommandParams` map contains the
+standard RP ID hash and the private metadata-only flag:
+
+```cbor
+{
+  0x01: h'<32-byte rpIdHash>',
+  0x80: true
+}
+```
+
+The complete request has the standard credential management shape:
+
+```cbor
+{
+  0x01: 0x04,
+  0x02: {
+    0x01: h'<32-byte rpIdHash>',
+    0x80: true
+  },
+  0x03: pinUvAuthProtocol,
+  0x04: pinUvAuthParam
+}
+```
+
+`pinUvAuthParam` authenticates the complete parameter map, including the
+extension flag:
+
+```text
+subCommand || canonicalCbor(subCommandParams)
+```
+
+Including the flag in the authenticated message prevents the requested mode
+from being changed independently of the authenticated request. Integer keys
+are encoded in canonical order, so `0x01` precedes `0x80`.
+
+## Response
+
+A metadata-only response omits the standard `publicKey` field (`0x08`) and
+returns the credential's COSE algorithm ID in private field `0x80`:
+
+```cbor
+{
+  ...standard credential fields,
+  0x80: -7
+}
+```
+
+The algorithm ID is retained because clients may need to identify the type of
+credential even when they do not need the full key. It is small, stable, and
+already defined by COSE, so duplicating the key solely to preserve this
+information would defeat the purpose of the extension.
+
+Currently used algorithm IDs are:
+
+| ID | Algorithm |
+| ---: | --- |
+| `-7` | ES256 |
+| `-8` | EdDSA |
+| `-49` | ML-DSA-65 |
+
+All other response fields retain their standard credential management meaning
+and encoding.
+
+## Pagination State
+
+The metadata-only flag is sent only with Begin. The authenticator retains the
+mode for the active enumeration, so subsequent
+`enumerateCredentialsGetNextCredential` (`0x05`) requests contain no
+`subCommandParams`.
+
+This design follows the existing stateful enumeration model and avoids adding
+parameters to a subcommand that does not accept them. Sending `0x80` with
+GetNext is invalid and may result in `CTAP2_ERR_INVALID_SUBCOMMAND`.
+
+Starting another normal Begin request without `0x80` replaces the active
+enumeration state and restores standard responses with complete public keys.
+
+## Compatibility
+
+Clients distinguish the response form by its fields:
+
+1. If `0x80` is present and `0x08` is absent, parse a metadata-only response.
+2. If `0x08` is present, parse the standard response and obtain the algorithm
+   ID from the COSE public key.
+
+The second case allows a client to request metadata-only enumeration while
+remaining compatible with implementations that return the standard response
+shape. The `CmCredentialMetadata.metadataOnly` property reports which response
+form was received, and `publicKey` remains available when the standard form is
+used.
+
+## Dart API
+
+Use `CredentialManagement.enumerateCredentialsMetadataOnly` to request the
+extension:
+
+```dart
+final credentials =
+    await credentialManagement.enumerateCredentialsMetadataOnly(rpIdHash);
+
+for (final credential in credentials) {
+  print(credential.credentialId);
+  print(credential.coseAlgorithm);
+}
+```
+
+The existing `enumerateCredentials` API remains unchanged and always requests
+standard responses with complete public keys.

--- a/lib/src/ctap2/credmgmt.dart
+++ b/lib/src/ctap2/credmgmt.dart
@@ -28,7 +28,8 @@ enum CredentialManagementSubCommand {
 enum CredentialManagementSubCommandParams {
   rpIdHash(0x01),
   credentialId(0x02),
-  user(0x03);
+  user(0x03),
+  metadataOnly(0x80);
 
   const CredentialManagementSubCommandParams(this.value);
 
@@ -55,11 +56,7 @@ class CmRp with JsonToStringMixin {
   final List<int> rpIdHash;
   final int? totalRPs;
 
-  CmRp({
-    required this.rp,
-    required this.rpIdHash,
-    this.totalRPs,
-  });
+  CmRp({required this.rp, required this.rpIdHash, this.totalRPs});
 
   @override
   Map<String, dynamic> toJson() => _$CmRpToJson(this);
@@ -87,6 +84,37 @@ class CmCredential with JsonToStringMixin {
   Map<String, dynamic> toJson() => _$CmCredentialToJson(this);
 }
 
+/// Credential fields returned by metadata-only enumeration.
+///
+/// Authenticators that do not support the extension may still return a
+/// standard [publicKey]. In that case [metadataOnly] is false and
+/// [coseAlgorithm] is read from the COSE key.
+@JsonSerializable(createFactory: false, explicitToJson: true)
+class CmCredentialMetadata with JsonToStringMixin {
+  final PublicKeyCredentialUserEntity user;
+  final PublicKeyCredentialDescriptor credentialId;
+  final int coseAlgorithm;
+  final bool metadataOnly;
+  final CoseKey? publicKey;
+  final int? totalCredentials;
+  final int credProtect;
+  final List<int>? largeBlobKey;
+
+  CmCredentialMetadata({
+    required this.user,
+    required this.credentialId,
+    required this.coseAlgorithm,
+    required this.metadataOnly,
+    this.publicKey,
+    this.totalCredentials,
+    required this.credProtect,
+    this.largeBlobKey,
+  });
+
+  @override
+  Map<String, dynamic> toJson() => _$CmCredentialMetadataToJson(this);
+}
+
 class CredentialManagement {
   final Ctap2 _ctap;
   final PinProtocol _pinProtocol;
@@ -95,7 +123,8 @@ class CredentialManagement {
   CredentialManagement(this._ctap, this._pinProtocol, this._pinToken) {
     if (!isSupported(_ctap.info)) {
       throw UnsupportedError(
-          'The authenticator does not support CredentialManagement command.');
+        'The authenticator does not support CredentialManagement command.',
+      );
     }
   }
 
@@ -105,8 +134,9 @@ class CredentialManagement {
   }
 
   Future<CmMetadata> getMetadata() async {
-    final resp =
-        await _invoke(CredentialManagementSubCommand.getCredsMetadata.value);
+    final resp = await _invoke(
+      CredentialManagementSubCommand.getCredsMetadata.value,
+    );
     if (resp.status != 0) {
       throw CtapError.fromCode(resp.status);
     }
@@ -119,8 +149,9 @@ class CredentialManagement {
   }
 
   Future<CmRp> enumerateRpsBegin() async {
-    final resp =
-        await _invoke(CredentialManagementSubCommand.enumerateRpsBegin.value);
+    final resp = await _invoke(
+      CredentialManagementSubCommand.enumerateRpsBegin.value,
+    );
     if (resp.status != 0) {
       throw CtapError.fromCode(resp.status);
     }
@@ -133,15 +164,13 @@ class CredentialManagement {
 
   Future<CmRp> enumerateRpsGetNextRp() async {
     final resp = await _invoke(
-        CredentialManagementSubCommand.enumerateRpsGetNextRp.value,
-        auth: false);
+      CredentialManagementSubCommand.enumerateRpsGetNextRp.value,
+      auth: false,
+    );
     if (resp.status != 0) {
       throw CtapError.fromCode(resp.status);
     }
-    return CmRp(
-      rp: resp.data!.rp!,
-      rpIdHash: resp.data!.rpIdHash!,
-    );
+    return CmRp(rp: resp.data!.rp!, rpIdHash: resp.data!.rpIdHash!);
   }
 
   Future<List<CmRp>> enumerateRPs() async {
@@ -158,11 +187,13 @@ class CredentialManagement {
 
   Future<CmCredential> enumerateCredentialsBegin(List<int> rpIdHash) async {
     final resp = await _invoke(
-        CredentialManagementSubCommand.enumerateCredentialsBegin.value,
-        params: {
-          CredentialManagementSubCommandParams.rpIdHash.value:
-              CborBytes(rpIdHash)
-        });
+      CredentialManagementSubCommand.enumerateCredentialsBegin.value,
+      params: {
+        CredentialManagementSubCommandParams.rpIdHash.value: CborBytes(
+          rpIdHash,
+        ),
+      },
+    );
     if (resp.status != 0) {
       throw CtapError.fromCode(resp.status);
     }
@@ -178,9 +209,11 @@ class CredentialManagement {
 
   Future<CmCredential> enumerateCredentialsGetNextCredential() async {
     final resp = await _invoke(
-        CredentialManagementSubCommand
-            .enumerateCredentialsGetNextCredential.value,
-        auth: false);
+      CredentialManagementSubCommand
+          .enumerateCredentialsGetNextCredential
+          .value,
+      auth: false,
+    );
     if (resp.status != 0) {
       throw CtapError.fromCode(resp.status);
     }
@@ -205,38 +238,127 @@ class CredentialManagement {
     return credentials;
   }
 
+  /// Enumerates credentials without requesting their full public keys.
+  ///
+  /// The Begin request includes the extension's private `0x80: true` parameter.
+  /// GetNext requests contain no subCommandParams and inherit the mode from
+  /// Begin. A standard response containing `publicKey` is accepted as a
+  /// fallback for authenticators that do not support the extension.
+  Future<List<CmCredentialMetadata>> enumerateCredentialsMetadataOnly(
+    List<int> rpIdHash,
+  ) async {
+    final credentials = <CmCredentialMetadata>[];
+    var credential = await _enumerateCredentialsMetadataOnlyBegin(rpIdHash);
+    final totalCredentials = credential.totalCredentials!;
+    credentials.add(credential);
+    while (totalCredentials > credentials.length) {
+      credential = await _enumerateCredentialsMetadataOnlyGetNextCredential();
+      credentials.add(credential);
+    }
+    return credentials;
+  }
+
+  Future<CmCredentialMetadata> _enumerateCredentialsMetadataOnlyBegin(
+    List<int> rpIdHash,
+  ) async {
+    final resp = await _invoke(
+      CredentialManagementSubCommand.enumerateCredentialsBegin.value,
+      params: {
+        CredentialManagementSubCommandParams.rpIdHash.value: CborBytes(
+          rpIdHash,
+        ),
+        CredentialManagementSubCommandParams.metadataOnly.value: true,
+      },
+    );
+    if (resp.status != 0) {
+      throw CtapError.fromCode(resp.status);
+    }
+    return _credentialMetadataFromResponse(resp.data!, includeTotal: true);
+  }
+
+  Future<CmCredentialMetadata>
+  _enumerateCredentialsMetadataOnlyGetNextCredential() async {
+    final resp = await _invoke(
+      CredentialManagementSubCommand
+          .enumerateCredentialsGetNextCredential
+          .value,
+      auth: false,
+    );
+    if (resp.status != 0) {
+      throw CtapError.fromCode(resp.status);
+    }
+    return _credentialMetadataFromResponse(resp.data!);
+  }
+
+  CmCredentialMetadata _credentialMetadataFromResponse(
+    CredentialManagementResponse response, {
+    bool includeTotal = false,
+  }) {
+    final publicKey = response.publicKey;
+    final metadataOnly = publicKey == null && response.coseAlgorithm != null;
+    final coseAlgorithm =
+        publicKey?[CoseKey.algIdx] as int? ??
+        (metadataOnly ? response.coseAlgorithm : null);
+    if (coseAlgorithm == null) {
+      throw const FormatException(
+        'Credential response has neither a public key nor a COSE algorithm.',
+      );
+    }
+    return CmCredentialMetadata(
+      user: response.user!,
+      credentialId: response.credentialId!,
+      coseAlgorithm: coseAlgorithm,
+      metadataOnly: metadataOnly,
+      publicKey: publicKey,
+      totalCredentials: includeTotal ? response.totalCredentials! : null,
+      credProtect: response.credProtect!,
+      largeBlobKey: response.largeBlobKey,
+    );
+  }
+
   Future<void> deleteCredential(
-      PublicKeyCredentialDescriptor credentialId) async {
+    PublicKeyCredentialDescriptor credentialId,
+  ) async {
     final resp = await _invoke(
-        CredentialManagementSubCommand.deleteCredential.value,
-        params: {
-          CredentialManagementSubCommandParams.credentialId.value:
-              credentialId.toCbor()
-        });
+      CredentialManagementSubCommand.deleteCredential.value,
+      params: {
+        CredentialManagementSubCommandParams.credentialId.value: credentialId
+            .toCbor(),
+      },
+    );
     if (resp.status != 0) {
       throw CtapError.fromCode(resp.status);
     }
   }
 
-  Future<void> updateUserInformation(PublicKeyCredentialDescriptor credentialId,
-      PublicKeyCredentialUserEntity user) async {
+  Future<void> updateUserInformation(
+    PublicKeyCredentialDescriptor credentialId,
+    PublicKeyCredentialUserEntity user,
+  ) async {
     final resp = await _invoke(
-        CredentialManagementSubCommand.updateUserInformation.value,
-        params: {
-          CredentialManagementSubCommandParams.credentialId.value:
-              credentialId.toCbor(),
-          CredentialManagementSubCommandParams.user.value: user.toCbor()
-        });
+      CredentialManagementSubCommand.updateUserInformation.value,
+      params: {
+        CredentialManagementSubCommandParams.credentialId.value: credentialId
+            .toCbor(),
+        CredentialManagementSubCommandParams.user.value: user.toCbor(),
+      },
+    );
     if (resp.status != 0) {
       throw CtapError.fromCode(resp.status);
     }
   }
 
-  Future<CtapResponse<CredentialManagementResponse?>> _invoke(int subCommand,
-      {Map<int, dynamic>? params, bool auth = true}) async {
+  Future<CtapResponse<CredentialManagementResponse?>> _invoke(
+    int subCommand, {
+    Map<int, dynamic>? params,
+    bool auth = true,
+  }) async {
     CborMap? paramsMap;
-    var entries = params?.entries
-        .map((e) => MapEntry(CborSmallInt(e.key), CborValue(e.value)));
+    final sortedParams = params?.entries.toList()
+      ?..sort((a, b) => a.key.compareTo(b.key));
+    var entries = sortedParams?.map(
+      (e) => MapEntry(CborSmallInt(e.key), CborValue(e.value)),
+    );
     if (entries != null) {
       paramsMap = CborMap.fromEntries(entries);
     }
@@ -249,11 +371,13 @@ class CredentialManagement {
       }
       pinUvAuthParam = await _pinProtocol.authenticate(_pinToken, msg);
     }
-    return await _ctap.credentialManagement(CredentialManagementRequest(
-      subCommand: subCommand,
-      params: paramsMap,
-      pinUvAuthProtocol: _pinProtocol.version,
-      pinUvAuthParam: pinUvAuthParam,
-    ));
+    return await _ctap.credentialManagement(
+      CredentialManagementRequest(
+        subCommand: subCommand,
+        params: paramsMap,
+        pinUvAuthProtocol: _pinProtocol.version,
+        pinUvAuthParam: pinUvAuthParam,
+      ),
+    );
   }
 }

--- a/lib/src/ctap2/credmgmt.dart
+++ b/lib/src/ctap2/credmgmt.dart
@@ -210,8 +210,7 @@ class CredentialManagement {
   Future<CmCredential> enumerateCredentialsGetNextCredential() async {
     final resp = await _invoke(
       CredentialManagementSubCommand
-          .enumerateCredentialsGetNextCredential
-          .value,
+          .enumerateCredentialsGetNextCredential.value,
       auth: false,
     );
     if (resp.status != 0) {
@@ -277,11 +276,10 @@ class CredentialManagement {
   }
 
   Future<CmCredentialMetadata>
-  _enumerateCredentialsMetadataOnlyGetNextCredential() async {
+      _enumerateCredentialsMetadataOnlyGetNextCredential() async {
     final resp = await _invoke(
       CredentialManagementSubCommand
-          .enumerateCredentialsGetNextCredential
-          .value,
+          .enumerateCredentialsGetNextCredential.value,
       auth: false,
     );
     if (resp.status != 0) {
@@ -296,8 +294,7 @@ class CredentialManagement {
   }) {
     final publicKey = response.publicKey;
     final metadataOnly = publicKey == null && response.coseAlgorithm != null;
-    final coseAlgorithm =
-        publicKey?[CoseKey.algIdx] as int? ??
+    final coseAlgorithm = publicKey?[CoseKey.algIdx] as int? ??
         (metadataOnly ? response.coseAlgorithm : null);
     if (coseAlgorithm == null) {
       throw const FormatException(
@@ -322,8 +319,8 @@ class CredentialManagement {
     final resp = await _invoke(
       CredentialManagementSubCommand.deleteCredential.value,
       params: {
-        CredentialManagementSubCommandParams.credentialId.value: credentialId
-            .toCbor(),
+        CredentialManagementSubCommandParams.credentialId.value:
+            credentialId.toCbor(),
       },
     );
     if (resp.status != 0) {
@@ -338,8 +335,8 @@ class CredentialManagement {
     final resp = await _invoke(
       CredentialManagementSubCommand.updateUserInformation.value,
       params: {
-        CredentialManagementSubCommandParams.credentialId.value: credentialId
-            .toCbor(),
+        CredentialManagementSubCommandParams.credentialId.value:
+            credentialId.toCbor(),
         CredentialManagementSubCommandParams.user.value: user.toCbor(),
       },
     );

--- a/lib/src/ctap2/credmgmt.g.dart
+++ b/lib/src/ctap2/credmgmt.g.dart
@@ -29,3 +29,16 @@ Map<String, dynamic> _$CmCredentialToJson(CmCredential instance) =>
       'credProtect': instance.credProtect,
       'largeBlobKey': instance.largeBlobKey,
     };
+
+Map<String, dynamic> _$CmCredentialMetadataToJson(
+        CmCredentialMetadata instance) =>
+    <String, dynamic>{
+      'user': instance.user.toJson(),
+      'credentialId': instance.credentialId.toJson(),
+      'coseAlgorithm': instance.coseAlgorithm,
+      'metadataOnly': instance.metadataOnly,
+      'publicKey': instance.publicKey?.toJson(),
+      'totalCredentials': instance.totalCredentials,
+      'credProtect': instance.credProtect,
+      'largeBlobKey': instance.largeBlobKey,
+    };

--- a/lib/src/ctap2/requests/credential_mgmt.dart
+++ b/lib/src/ctap2/requests/credential_mgmt.dart
@@ -75,6 +75,7 @@ class CredentialManagementResponse with JsonToStringMixin {
   static const int totalCredentialsIdx = 9;
   static const int credProtectIdx = 10;
   static const int largeBlobKeyIdx = 11;
+  static const int coseAlgorithmIdx = 0x80;
 
   /// Number of existing discoverable credentials on the authenticator.
   final int? existingResidentCredentialsCount;
@@ -109,6 +110,9 @@ class CredentialManagementResponse with JsonToStringMixin {
   /// Large blob encryption key.
   final List<int>? largeBlobKey;
 
+  /// COSE algorithm ID returned by the metadata-only extension.
+  final int? coseAlgorithm;
+
   CredentialManagementResponse({
     this.existingResidentCredentialsCount,
     this.maxPossibleRemainingResidentCredentialsCount,
@@ -121,6 +125,7 @@ class CredentialManagementResponse with JsonToStringMixin {
     this.totalCredentials,
     this.credProtect,
     this.largeBlobKey,
+    this.coseAlgorithm,
   });
 
   /// Decodes a CBOR-encoded response into [CredentialManagementResponse].
@@ -128,8 +133,8 @@ class CredentialManagementResponse with JsonToStringMixin {
     final map = cbor.decode(data).toObject() as Map;
     final rpMap = (map[rpIdx] as Map?)?.cast<String, dynamic>();
     final userMap = (map[userIdx] as Map?)?.cast<String, dynamic>();
-    final credentialIdMap =
-        (map[credentialIdIdx] as Map?)?.cast<String, dynamic>();
+    final credentialIdMap = (map[credentialIdIdx] as Map?)
+        ?.cast<String, dynamic>();
     final publicKeyMap = (map[publicKeyIdx] as Map?)?.cast<int, dynamic>();
     return CredentialManagementResponse(
       existingResidentCredentialsCount:
@@ -149,6 +154,7 @@ class CredentialManagementResponse with JsonToStringMixin {
       totalCredentials: map[totalCredentialsIdx] as int?,
       credProtect: map[credProtectIdx] as int?,
       largeBlobKey: (map[largeBlobKeyIdx] as List?)?.cast<int>(),
+      coseAlgorithm: map[coseAlgorithmIdx] as int?,
     );
   }
 

--- a/lib/src/ctap2/requests/credential_mgmt.dart
+++ b/lib/src/ctap2/requests/credential_mgmt.dart
@@ -133,8 +133,8 @@ class CredentialManagementResponse with JsonToStringMixin {
     final map = cbor.decode(data).toObject() as Map;
     final rpMap = (map[rpIdx] as Map?)?.cast<String, dynamic>();
     final userMap = (map[userIdx] as Map?)?.cast<String, dynamic>();
-    final credentialIdMap = (map[credentialIdIdx] as Map?)
-        ?.cast<String, dynamic>();
+    final credentialIdMap =
+        (map[credentialIdIdx] as Map?)?.cast<String, dynamic>();
     final publicKeyMap = (map[publicKeyIdx] as Map?)?.cast<int, dynamic>();
     return CredentialManagementResponse(
       existingResidentCredentialsCount:

--- a/lib/src/ctap2/requests/credential_mgmt.g.dart
+++ b/lib/src/ctap2/requests/credential_mgmt.g.dart
@@ -31,4 +31,5 @@ Map<String, dynamic> _$CredentialManagementResponseToJson(
       'totalCredentials': instance.totalCredentials,
       'credProtect': instance.credProtect,
       'largeBlobKey': instance.largeBlobKey,
+      'coseAlgorithm': instance.coseAlgorithm,
     };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fido2
 description: Library to parse FIDO2 request / response and interactive with authenticators via CTAP2.
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/nfcim/fido2
 
 environment:

--- a/test/fido2_credmgmt_test.dart
+++ b/test/fido2_credmgmt_test.dart
@@ -1,0 +1,145 @@
+import 'package:cbor/cbor.dart';
+import 'package:fido2/fido2.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final rpIdHash = List<int>.generate(32, (index) => index);
+  final pinToken = List<int>.generate(32, (index) => 0xa0 + index);
+
+  test(
+    'metadata-only Begin is authenticated and GetNext has no params',
+    () async {
+      final device = _CredentialManagementDevice([
+        _credentialResponse(
+          userId: [1],
+          coseAlgorithm: -49,
+          totalCredentials: 2,
+          metadataOnly: true,
+        ),
+        _credentialResponse(userId: [2], coseAlgorithm: -8, metadataOnly: true),
+      ]);
+      final ctap = await Ctap2.create(device);
+      final pinProtocol = PinProtocolV1();
+      final manager = CredentialManagement(ctap, pinProtocol, pinToken);
+
+      final credentials = await manager.enumerateCredentialsMetadataOnly(
+        rpIdHash,
+      );
+
+      expect(credentials, hasLength(2));
+      expect(credentials[0].coseAlgorithm, -49);
+      expect(credentials[0].metadataOnly, isTrue);
+      expect(credentials[0].publicKey, isNull);
+      expect(credentials[1].coseAlgorithm, -8);
+
+      final begin = _decodeRequest(device.commands[1]);
+      expect(begin[1], 0x04);
+      final params = (begin[2] as Map).cast<int, dynamic>();
+      expect(params, {1: rpIdHash, 0x80: true});
+      expect(begin[3], 1);
+
+      final canonicalParams = CborMap({
+        const CborSmallInt(1): CborBytes(rpIdHash),
+        const CborSmallInt(0x80): const CborBool(true),
+      });
+      final authenticationMessage = <int>[
+        0x04,
+        ...cbor.encode(canonicalParams),
+      ];
+      expect(
+        begin[4],
+        await pinProtocol.authenticate(pinToken, authenticationMessage),
+      );
+
+      final getNext = _decodeRequest(device.commands[2]);
+      expect(getNext.containsKey(2), isFalse);
+      expect(getNext[1], 0x05);
+    },
+  );
+
+  test('metadata enumeration accepts a standard public-key response', () async {
+    final device = _CredentialManagementDevice([
+      _credentialResponse(
+        userId: [3],
+        coseAlgorithm: -7,
+        totalCredentials: 1,
+        metadataOnly: false,
+      ),
+    ]);
+    final ctap = await Ctap2.create(device);
+    final manager = CredentialManagement(ctap, PinProtocolV1(), pinToken);
+
+    final credentials = await manager.enumerateCredentialsMetadataOnly(
+      rpIdHash,
+    );
+
+    expect(credentials, hasLength(1));
+    expect(credentials.single.coseAlgorithm, -7);
+    expect(credentials.single.metadataOnly, isFalse);
+    expect(credentials.single.publicKey, isA<ES256>());
+  });
+}
+
+Map<dynamic, dynamic> _decodeRequest(List<int> command) {
+  expect(command.first, Ctap2Commands.credentialManagement.value);
+  return (cbor.decode(command.sublist(1)).toObject() as Map)
+      .cast<dynamic, dynamic>();
+}
+
+List<int> _credentialResponse({
+  required List<int> userId,
+  required int coseAlgorithm,
+  required bool metadataOnly,
+  int? totalCredentials,
+}) {
+  final response = <int, dynamic>{
+    6: {
+      'id': CborBytes(userId),
+      'name': 'user-${userId.single}',
+      'displayName': 'User ${userId.single}',
+    },
+    7: {
+      'type': 'public-key',
+      'id': CborBytes([0x40 + userId.single]),
+    },
+    if (totalCredentials != null) 9: totalCredentials,
+    10: 1,
+  };
+  if (metadataOnly) {
+    response[0x80] = coseAlgorithm;
+  } else {
+    response[8] = {
+      1: 2,
+      3: coseAlgorithm,
+      -1: 1,
+      -2: CborBytes(List<int>.filled(32, 1)),
+      -3: CborBytes(List<int>.filled(32, 2)),
+    };
+  }
+  return cbor.encode(CborValue(response));
+}
+
+class _CredentialManagementDevice extends CtapDevice {
+  final List<List<int>> responses;
+  final List<List<int>> commands = [];
+
+  _CredentialManagementDevice(this.responses);
+
+  @override
+  Future<CtapResponse<List<int>>> transceive(List<int> command) async {
+    commands.add(command);
+    if (command.first == Ctap2Commands.getInfo.value) {
+      return CtapResponse(
+        0,
+        cbor.encode(
+          CborValue({
+            1: ['FIDO_2_1'],
+            3: CborBytes(List<int>.filled(16, 0)),
+            4: {'credMgmt': true},
+          }),
+        ),
+      );
+    }
+    return CtapResponse(0, responses[commands.length - 2]);
+  }
+}


### PR DESCRIPTION
## Summary

- add the metadata-only extension for credential enumeration
- expose `CredentialManagement.enumerateCredentialsMetadataOnly`
- preserve the existing standard enumeration API and its non-null public-key contract
- document the extension protocol and design rationale

## Why

Standard credential enumeration returns a complete COSE public key for every
credential. Management clients commonly need only the user, credential ID,
protection policy, and algorithm when listing credentials. Transferring full
keys adds avoidable latency on constrained transports, especially for
algorithms with larger public keys.

The extension reuses the standard credential management command and
enumeration subcommands. This preserves the existing authorization,
pagination, response fields, and error behavior instead of introducing a
parallel protocol.

## Protocol

- Begin adds private `subCommandParams` field `0x80: true` alongside `rpIdHash`.
- `pinUvAuthParam` authenticates `subCommand || canonicalCbor(subCommandParams)`,
  including the extension field.
- Metadata-only responses omit `publicKey` (`0x08`) and return the COSE
  algorithm ID in private field `0x80`.
- GetNext carries no `subCommandParams`; the mode is inherited from Begin.
- A later normal Begin without `0x80` restores complete public-key responses.

## Compatibility

The response parser treats `0x80` without `0x08` as metadata-only. If `0x08`
is present, it parses the standard response and derives the algorithm from the
COSE key. This supports implementations that accept the request but continue
to return the standard response shape.

## Validation

- `dart format --output=none --set-exit-if-changed .`
- `dart analyze`
- `dart test` (36 tests)

See `docs/metadata-only-extension.md` for the complete wire format and design
details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metadata-only credential enumeration to retrieve credential details without transferring complete public keys.
  * Added support for COSE algorithm responses, pagination, authentication, and compatibility fallbacks.
  * Introduced a structured credential metadata result with optional public-key information.

* **Documentation**
  * Added a guide and updated CTAP2 usage documentation.
  * Documented request parameters, response formats, supported algorithms, and compatibility behavior.

* **Tests**
  * Added coverage for metadata-only enumeration, authentication, pagination, and standard responses.

* **Chores**
  * Updated the package version to 1.2.0 and changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->